### PR TITLE
Add onModify callback to JVM implementation

### DIFF
--- a/multiplatform-settings/src/jvmMain/kotlin/com/russhwolf/settings/JvmSettings.kt
+++ b/multiplatform-settings/src/jvmMain/kotlin/com/russhwolf/settings/JvmSettings.kt
@@ -32,25 +32,37 @@ import java.util.Properties
  * syntax and better type-safety when interacting with values stored in a `Settings` instance.
  *
  * On the JVM platform, this class can be created by passing a [Properties] instance which will be used as a delegate.
+ * Since the [Properties] doesn't perform the serialization and writing of the data by itself, a callback needs to be
+ * added, which makes the user of this class responsible for persisting the data every time the data set is updated.
  *
  * Unlike the implementations on Android and iOS, `JvmSettings` does not include a [Settings.Factory] because
  * the `Properties` API does not provide a natural way to create multiple named instances.
  *
  * This class is experimental as marked by the [ExperimentalJvm] annotation.
- *
  * The experimental listener APIs are not implemented in `JvmSettings`.
+ *
+ * @param delegate The [Properties] object to wrap
+ * @param onModify The callback that is responsible for saving the changes to the disk
  */
 @ExperimentalJvm
-public class JvmSettings public constructor(private val delegate: Properties) : Settings {
-    public override fun clear(): Unit = delegate.clear()
+public class JvmSettings public constructor(private val delegate: Properties,
+                                            private val onModify: (Properties) -> Unit) : Settings {
+
+    public override fun clear(): Unit {
+        delegate.clear()
+        onModify(delegate)
+    }
+
     public override fun remove(key: String) {
         delegate.remove(key)
+        onModify(delegate)
     }
 
     public override fun hasKey(key: String): Boolean = delegate[key] != null
 
     public override fun putInt(key: String, value: Int) {
         delegate.setProperty(key, value.toString())
+        onModify(delegate)
     }
 
     public override fun getInt(key: String, defaultValue: Int): Int =
@@ -58,6 +70,7 @@ public class JvmSettings public constructor(private val delegate: Properties) : 
 
     public override fun putLong(key: String, value: Long) {
         delegate.setProperty(key, value.toString())
+        onModify(delegate)
     }
 
     public override fun getLong(key: String, defaultValue: Long): Long =
@@ -66,6 +79,7 @@ public class JvmSettings public constructor(private val delegate: Properties) : 
 
     public override fun putString(key: String, value: String) {
         delegate.setProperty(key, value)
+        onModify(delegate)
     }
 
     public override fun getString(key: String, defaultValue: String): String =
@@ -74,6 +88,7 @@ public class JvmSettings public constructor(private val delegate: Properties) : 
 
     public override fun putFloat(key: String, value: Float) {
         delegate.setProperty(key, value.toString())
+        onModify(delegate)
     }
 
     public override fun getFloat(key: String, defaultValue: Float): Float =
@@ -82,6 +97,7 @@ public class JvmSettings public constructor(private val delegate: Properties) : 
 
     public override fun putDouble(key: String, value: Double) {
         delegate.setProperty(key, value.toString())
+        onModify(delegate)
     }
 
     public override fun getDouble(key: String, defaultValue: Double): Double =
@@ -90,6 +106,7 @@ public class JvmSettings public constructor(private val delegate: Properties) : 
 
     public override fun putBoolean(key: String, value: Boolean) {
         delegate.setProperty(key, value.toString())
+        onModify(delegate)
     }
 
     public override fun getBoolean(key: String, defaultValue: Boolean): Boolean =


### PR DESCRIPTION
Hi!

I'm currently using your library in my multiplatform project, targeting Android+JS+JVM (Desktop).

By looking at the various implementations of the Settings interface, I see that the contract for its modifying methods (clear, remove, putXXX) is that calling them ensures that every step of the persistence is taken care of, after each call. This is currently not the case with the current JVM implementation, because the Properties class doesn't do that, you have to call store or save explicitly.

My solution to the issue is to add a callback, which is called after each modification event of the data set. That way the application's "JVM code" will be responsible for providing the exact way on how to handle it, and for the "common side", the interface would continue to abide the contract, that every put method call's result is being persisted.
This solution worked for my project perfectly, so I decided to share it.

An example looks something like this:

```
JvmSettings(properties) { props ->
        FileOutputStream("/path/to/file/mydata.settings").use { fos ->
            props.store(fos, "")
        }
    }
```

