### PR TITLE
First cut of a Github Actions based CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: build
+      - run: git diff --exit-code
+        if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,7 @@ jobs:
       - uses: eskatos/gradle-command-action@v1
         with:
           arguments: build
+        env:
+          CI: true
       - run: git diff --exit-code
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1

--- a/multiplatform-settings-test/build.gradle.kts
+++ b/multiplatform-settings-test/build.gradle.kts
@@ -131,7 +131,7 @@ android {
 }
 
 task("iosTest") {
-    onlyIf { System.getProperty("os.name").toLowerCase().contains("mac") }
+    onlyIf { System.getProperty("os.name").toLowerCase().contains("mac") && System.getenv("CI") != "true" }
     dependsOn("linkDebugTestIosSim")
     doLast {
         val testBinaryPath =

--- a/multiplatform-settings-test/build.gradle.kts
+++ b/multiplatform-settings-test/build.gradle.kts
@@ -131,6 +131,7 @@ android {
 }
 
 task("iosTest") {
+    onlyIf { System.getProperty("os.name").toLowerCase().contains("mac") }
     dependsOn("linkDebugTestIosSim")
     doLast {
         val testBinaryPath =

--- a/multiplatform-settings/build.gradle.kts
+++ b/multiplatform-settings/build.gradle.kts
@@ -135,7 +135,7 @@ android {
 }
 
 task("iosTest") {
-    onlyIf { System.getProperty("os.name").toLowerCase().contains("mac") }
+    onlyIf { System.getProperty("os.name").toLowerCase().contains("mac") && System.getenv("CI") != "true" }
     dependsOn("linkDebugTestIosSim")
     doLast {
         val testBinaryPath =

--- a/multiplatform-settings/build.gradle.kts
+++ b/multiplatform-settings/build.gradle.kts
@@ -135,6 +135,7 @@ android {
 }
 
 task("iosTest") {
+    onlyIf { System.getProperty("os.name").toLowerCase().contains("mac") }
     dependsOn("linkDebugTestIosSim")
     doLast {
         val testBinaryPath =

--- a/sample/shared/build.gradle.kts
+++ b/sample/shared/build.gradle.kts
@@ -42,7 +42,7 @@ kotlin {
                 useExperimentalAnnotation("kotlin.Experimental")
             }
         }
-        
+
         commonMain {
             dependencies {
                 implementation("com.russhwolf:multiplatform-settings:${rootProject.ext["library_version"]}")
@@ -52,7 +52,7 @@ kotlin {
         commonTest {
             dependencies {
                 implementation("com.russhwolf:multiplatform-settings-test:${rootProject.ext["library_version"]}")
-                
+
                 implementation(kotlin("test"))
                 implementation(kotlin("test-annotations-common"))
             }
@@ -106,7 +106,7 @@ task("copyFramework") {
 }
 
 task("iosTest") {
-    onlyIf { System.getProperty("os.name").toLowerCase().contains("mac") }
+    onlyIf { System.getProperty("os.name").toLowerCase().contains("mac") && System.getenv("CI") != "true" }
     dependsOn("linkDebugTestIos")
     doLast {
         val testBinaryPath =

--- a/sample/shared/build.gradle.kts
+++ b/sample/shared/build.gradle.kts
@@ -106,6 +106,7 @@ task("copyFramework") {
 }
 
 task("iosTest") {
+    onlyIf { System.getProperty("os.name").toLowerCase().contains("mac") }
     dependsOn("linkDebugTestIos")
     doLast {
         val testBinaryPath =


### PR DESCRIPTION
See https://github.com/russhwolf/multiplatform-settings/issues/21

It simply runs `./gradlew build` on linux and macos agents.

I think you'd need to signup for the Github Actions beta at https://github.com/features/actions for it to be enabled on this repository.

You can see the results on my fork at https://github.com/eskatos/multiplatform-settings/actions

I had to disable the windows agents because the tests obviously [fail](https://github.com/eskatos/multiplatform-settings/runs/241688368#step:4:527). It's simple to add back, see https://github.com/russhwolf/multiplatform-settings/commit/03f6ef16e03616f9af3a7d8a25df9c3b80ddee99

I had to skip the `iosTest` tasks on non mac-machines because they can't run on linux nor windows but also skip them on CI on mac because there's no simulator available out of the box.

Feel free to discard if you want to use a different CI environment.