### PR TITLE
Update for Kotlin 1.3.60

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,13 +15,13 @@
  */
 
 plugins {
-    kotlin("multiplatform") version "1.3.50" apply false
+    kotlin("multiplatform") version "1.3.60" apply false
     id("com.android.library") version "3.5.0" apply false
 }
 
 subprojects {
     group = "com.russhwolf"
-    version = "0.4"
+    version = "0.4.1"
 
     repositories {
         google()


### PR DESCRIPTION
Not much of a change. I see there's a lot of azure commits, but we need 1.3.60 ...