### PR TITLE
Update README.md with proper syntax highlighting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,21 @@ This is a Kotlin library for Multiplatform apps, so that common code can persist
 
 ## Adding to your project
 Multiplatform Settings is currently published to jcenter, so add that to repositories.
-
+```
     repositories {
         ...
         jcenter()
     }
-
+```
 Then, simply add the dependency to your common source-set dependencies
-
+```
     commonMain {
         dependencies {
             ...
             implementation "com.russhwolf:multiplatform-settings:0.5"
         }
     }
-    
+   ``` 
 See also the sample project, which uses this structure.
 
 ## Usage
@@ -26,83 +26,83 @@ See also the sample project, which uses this structure.
 The `Settings` interface has implementations on the Android, iOS, macOS, watchOOS, tvOS, JS, and JVM platforms. (Note that the two JVM implementations are currently marked as experimental.)
 
 The Android implementation is `AndroidSettings`, which wraps `SharedPreferences`.
-
+```kotlin
     val delegate: SharedPreferences = ...
     val settings: Settings = AndroidSettings(delegate)
-
+```
 On iOS, macOS, tvOS, or watchOS, `AppleSettings` wraps `NSUserDefaults`.
-
+```kotlin
     val delegate: NSUserDefaults = ...
     val settings: Settings = AppleSettings(delegate)
-    
+```
 On JS, `JsSettings` wraps `Storage`.
-    
+```kotlin
     val delegate: Storage = ...
     val settings: Settings = JsSettings(delegate)
     
     val settings: Settings = JsSettings() // use localStorage by default
-        
+```     
 Once the `Settings` instance is created, you can store values by calling the various `putXXX()` methods, or their operator shortcuts
-
+```kotlin
     settings.putInt("key", 3)
     settings["key"] = 3
-    
+```
 You can retrieve stored values via the `getXXX()` methods or their operator shortcuts. If a key is not present, then the supplied default will be returned instead.
-
+```kotlin
     val a: Int = settings.getInt("key")
     val b: Int = settings.getInt("key", defaultValue = -1) 
     val c: Int = settings["key", -1]
-    
+```    
 Nullable methods are also available to avoid the need to use a default value. Instead, `null` will be returned if a key is not present.
-
+```kotlin
     val a: Int? = settings.getIntOrNull("key")
     val b: Int? = settings["key"]
-    
+```    
 The `getXXX()` and `putXXX()` operation for a given key can be wrapped using a property delegate. This has the advantage of ensuring that the key is always accessed with a consistent type.
-
+```kotlin
     val a: Int by settings.int("key")
     val b: Int by settings.int("key", defaultValue = -1)
-    
+```    
 Nullable delegates exists so that absence of a key can be indicated by `null` instead of a default value
-    
+```kotlin    
     val a: Int? by settings.nullableInt("key")
-    
+```    
 The `key` parameter can be omitted for delegates, and the property name will be reflectively used instead.
-
+```kotlin
     val a: Int by settings.int() // internally, key is "a"
-    
+```
 Existence of a key can be queried
-     
+```kotlin     
     val a: Boolean = settings.hasKey("key")
     val b: Boolean = "key" in settings
-     
+```     
  Values can also be removed by key
-  
+ ```kotlin 
     settings.remove("key")
     settings -= "key"
     settings["key"] = null
-  
+ ``` 
  Finally, all values in a `Settings` instance can be removed
-      
+ ```kotlin     
     settings.clear()
-
+```
 For the Android, iOS, and macOS platforms, a `Factory` class also exists, so that multiple named `Settings` instances can coexist with the names being controlled from common code.
 
 On Android, this factory needs a `Context` parameter
-
+```kotlin
     val context: Context = ...
     val factory: Settings.Factory = AndroidSettings.Factory(context)
-    
+```    
 On iOS and macOS, the factory can be instantiated without passing any parameter
-
+```kotlin
     val factory: Settings.Factory = AppleSettings.Factory()
-    
+```    
 ## Testing
 
 A testing dependency is available to aid in testing code that interacts with this library.
-
+```
     implementation "com.russhwolf:multiplatform-settings-test:0.5"
-    
+```    
 This includes a `MockSettings` implementation of the `Settings` interface, which is backed by an in-memory `MutableMap` on all platforms.
 
 ## Other platforms
@@ -116,23 +116,23 @@ This is a pre-1.0 library based on an experimental framework, so some occasional
 ### Experimental Platforms
 
 Two pure-JVM implementations exist. `JvmPreferencesSettings` wraps `Preferences` and `JvmPropertiesSettings` wraps `Properties`. Their experimental status is marked with the `@ExperimentalJvm` annotation. 
-
+```kotlin
     val delegate: Preferences = ...
     val settings: Settings = JvmPreferencesSettings(delegate)
 
     val delegate: Properties = ...
     val settings: Settings = JvmPropertiesSettings(delegate)
-        
+```        
 ### Listeners
 
 Update listeners are available using an experimental API, only for the `AndroidSettings`, `AppleSettings`, and `JvmPreferencesSettings` implementations. These are marked with the `ObservableSettings` interface, which includes `addListener()` and `removeListener()` methods.
-
+```kotlin
     val settingsListener: SettingsListener = settings.addListener(key) { ... }
-    
+```    
 The `SettingsListener` returned from the call should be used to signal when you're done listening:
-
+```kotlin
     settingsListener.deactivate()
-    
+```    
 This current listener implementation is not designed with any sort of thread-safety so it's recommended to only interact with these APIs from the main thread of your application.
 
 The listener APIs make use of the Kotlin `@ExperimentalListener` annotation.


### PR DESCRIPTION
This change makes the `README.md` code snippets more readable with proper syntax highlighting for `Kotlin`.