### PR TITLE
Thread-safety for AppleSettings background listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,7 @@ The `SettingsListener` returned from the call should be used to signal when you'
 settingsListener.deactivate()
 ```    
 
-On Apple platforms, the `AppleSettings` listeners are designed to work within the Kotlin/Native threading model. If all interaction with the class is on a single thread, then nothing will be frozen. In multithreaded usage, calling `AppleSettings.freeze()` triggers the freezing of listeners as well, making it safe to set listeners when the class might be used across threads.
-
-This current listener implementation is not designed with any sort of thread-safety so it's recommended to only interact with these APIs from the main thread of your application.
+On Apple platforms, the `AppleSettings` listeners are designed to work within the Kotlin/Native threading model. If all interaction with the class is on a single thread, then nothing will be frozen. In multithreaded usage, the `AppleSettings` can be configured to freeze listeners, making it safe to set listeners when the class might be used across threads.
 
 The listener APIs make use of the Kotlin `@ExperimentalListener` annotation.
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ The `SettingsListener` returned from the call should be used to signal when you'
 settingsListener.deactivate()
 ```    
 
+On Apple platforms, the `AppleSettings` listeners are designed to work within the Kotlin/Native threading model. If all interaction with the class is on a single thread, then nothing will be frozen. In multithreaded usage, calling `AppleSettings.freeze()` triggers the freezing of listeners as well, making it safe to set listeners when the class might be used across threads.
+
 This current listener implementation is not designed with any sort of thread-safety so it's recommended to only interact with these APIs from the main thread of your application.
 
 The listener APIs make use of the Kotlin `@ExperimentalListener` annotation.

--- a/multiplatform-settings/src/appleMain/kotlin/com/russhwolf/settings/AppleSettings.kt
+++ b/multiplatform-settings/src/appleMain/kotlin/com/russhwolf/settings/AppleSettings.kt
@@ -24,7 +24,6 @@ import platform.Foundation.NSUserDefaultsDidChangeNotification
 import platform.darwin.NSObjectProtocol
 import kotlin.native.concurrent.AtomicReference
 import kotlin.native.concurrent.freeze
-import kotlin.native.concurrent.isFrozen
 
 /**
  * A collection of storage-backed key-value data
@@ -42,13 +41,24 @@ import kotlin.native.concurrent.isFrozen
  * On the iOS and macOS platforms, this class can be created by passing a [NSUserDefaults] instance which will be used as a
  * delegate, or via a [Factory].
  *
- * Note that this class is safe to freeze when used in a multi-threaded environment. It should be frozen prior to any
- * calls to [addListener] if it might be accessed from multiple threads. In that case, the listener block will be frozen
- * as well so that it can safely be triggered from any threads. To avoid freezing listeners, you should restrict
- * interaction with this class to a single thread and avoid freezing it.
+ * Note that this class is frozen on construction, and is safe to use in a multi-threaded environment. If the listener
+ * APIs will be used in such an environment, then [useFrozenListeners] should be set to true on creation. In that case,
+ * the block passed to [addListener] will be frozen as well so that it can safely be triggered from any thread. To avoid
+ * freezing listeners, restrict interaction with this class to a single thread and set `useFrozenListeners` to `false`.
  */
 @OptIn(ExperimentalListener::class)
-public class AppleSettings public constructor(private val delegate: NSUserDefaults) : ObservableSettings {
+public class AppleSettings public constructor(
+    private val delegate: NSUserDefaults,
+    private val useFrozenListeners: Boolean
+) : ObservableSettings {
+    init {
+        // We hold no state at the Kotlin level, so shouldn't run into freeze issues. If we know we're already frozen
+        // then if listeners freeze things it'll be less surprising
+        freeze()
+    }
+
+    // Secondary constructor instead of default parameter for backward-compatibility
+    constructor(delegate: NSUserDefaults) : this(delegate, useFrozenListeners = false)
 
     /**
      * A factory that can produce [Settings] instances.
@@ -136,31 +146,56 @@ public class AppleSettings public constructor(private val delegate: NSUserDefaul
 
     @ExperimentalListener
     public override fun addListener(key: String, callback: () -> Unit): SettingsListener {
-        val previousValue: AtomicReference<Any?> = AtomicReference(delegate.objectForKey(key))
-
-        val block = { _: NSNotification? ->
-            /*
-             We'll get called here on any update to the underlying NSUserDefaults delegate. We use a cache to determine
-             whether the value at this listener's key changed before calling the user-supplied callback.
-             */
-            val current = delegate.objectForKey(key)
-            if (previousValue.value != current) {
-                callback.invoke()
-                previousValue.value = current
-            }
+        val (block, previousValue) = if (useFrozenListeners) {
+            createBackgroundListener(key, callback)
+        } else {
+            createMainThreadListener(key, callback)
         }
-
-        // Freezing this AppleSettings signals that it may be used across threads, so we freeze the listener.
-        if (this.isFrozen) block.freeze()
-
         val observer = NSNotificationCenter.defaultCenter.addObserverForName(
             name = NSUserDefaultsDidChangeNotification,
             `object` = delegate,
             queue = null,
             usingBlock = block
         )
-
         return Listener(observer, previousValue)
+    }
+
+    private fun createMainThreadListener(
+        key: String,
+        callback: () -> Unit
+    ): Pair<(NSNotification?) -> Unit, AtomicReference<Any?>?> {
+        var previousValue = delegate.objectForKey(key)
+
+        return { _: NSNotification? ->
+            /*
+             We'll get called here on any update to the underlying NSUserDefaults delegate. We use a cache to determine
+             whether the value at this listener's key changed before calling the user-supplied callback.
+             */
+            val current = delegate.objectForKey(key)
+            if (previousValue != current) {
+                callback.invoke()
+                previousValue = current
+            }
+        } to null
+    }
+
+    private fun createBackgroundListener(
+        key: String,
+        callback: () -> Unit
+    ): Pair<(NSNotification?) -> Unit, AtomicReference<Any?>?> {
+        val previousValue: AtomicReference<Any?> = AtomicReference(delegate.objectForKey(key).freeze())
+
+        return { _: NSNotification? ->
+            /*
+             We'll get called here on any update to the underlying NSUserDefaults delegate. We use a cache to determine
+             whether the value at this listener's key changed before calling the user-supplied callback.
+             */
+            val current = delegate.objectForKey(key).freeze()
+            if (previousValue.value != current) {
+                callback.invoke()
+                previousValue.value = current
+            }
+        }.freeze() to previousValue
     }
 
     /**
@@ -171,11 +206,11 @@ public class AppleSettings public constructor(private val delegate: NSUserDefaul
     @ExperimentalListener
     public class Listener internal constructor(
         private val delegate: NSObjectProtocol,
-        private val previousValue: AtomicReference<Any?>
+        private val previousValue: AtomicReference<Any?>?
     ) : SettingsListener {
         override fun deactivate() {
             NSNotificationCenter.defaultCenter.removeObserver(delegate)
-            previousValue.value = null
+            previousValue?.value = null
         }
     }
 }

--- a/multiplatform-settings/src/appleTest/kotlin/com/russhwolf/settings/AppleSettingsBackgroundTest.kt
+++ b/multiplatform-settings/src/appleTest/kotlin/com/russhwolf/settings/AppleSettingsBackgroundTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 Russell Wolf
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.russhwolf.settings
+
+import platform.Foundation.NSThread
+import kotlin.native.concurrent.AtomicReference
+import kotlin.native.concurrent.TransferMode
+import kotlin.native.concurrent.Worker
+import kotlin.native.concurrent.freeze
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalListener::class)
+class AppleSettingsBackgroundTest : BaseSettingsTest(object : Settings.Factory {
+    val delegate = AppleSettings.Factory()
+    override fun create(name: String?): Settings {
+        return delegate.create(name).freeze()
+    }
+}) {
+
+    private val incrementedOnMainThread = AtomicReference<Boolean?>(null)
+
+    private fun observeThread() {
+        (settings as ObservableSettings).addListener("key") {
+            incrementedOnMainThread.value = NSThread.isMainThread
+        }
+    }
+
+    private fun incrementValue() {
+        settings["key"] = settings["key", 0] + 1
+    }
+
+    @Test
+    fun foreground() {
+        observeThread()
+        incrementValue()
+        assertEquals(true, incrementedOnMainThread.value)
+    }
+
+    @Test
+    fun background_single() {
+        doInBackground {
+            observeThread()
+            incrementValue()
+        }
+        assertEquals(false, incrementedOnMainThread.value)
+    }
+
+    @Test
+    fun background_multiple() {
+        doInBackground {
+            observeThread()
+        }
+        doInBackground {
+            incrementValue()
+        }
+        assertEquals(false, incrementedOnMainThread.value)
+    }
+
+    @Test
+    fun observe_background() {
+        doInBackground {
+            observeThread()
+        }
+        incrementValue()
+        assertEquals(true, incrementedOnMainThread.value)
+    }
+
+    @Test
+    fun increment_background() {
+        observeThread()
+        doInBackground {
+            incrementValue()
+        }
+        assertEquals(false, incrementedOnMainThread.value)
+    }
+}
+
+private fun <T> doInBackground(block: () -> T): T {
+    val worker = Worker.start()
+    val result = worker.execute(TransferMode.SAFE, { block.freeze() }, { it.invoke() }).result
+    worker.requestTermination()
+    return result
+}

--- a/multiplatform-settings/src/appleTest/kotlin/com/russhwolf/settings/AppleSettingsTest.kt
+++ b/multiplatform-settings/src/appleTest/kotlin/com/russhwolf/settings/AppleSettingsTest.kt
@@ -17,14 +17,10 @@
 package com.russhwolf.settings
 
 import platform.Foundation.NSUserDefaults
-import kotlin.native.concurrent.ensureNeverFrozen
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-private val factory = object : Settings.Factory {
-    val delegate = AppleSettings.Factory()
-    override fun create(name: String?): Settings = delegate.create(name).apply { ensureNeverFrozen() }
-}
+private val factory = AppleSettings.Factory()
 
 class AppleSettingsTest : BaseSettingsTest(factory) {
     @Test

--- a/multiplatform-settings/src/appleTest/kotlin/com/russhwolf/settings/AppleSettingsTest.kt
+++ b/multiplatform-settings/src/appleTest/kotlin/com/russhwolf/settings/AppleSettingsTest.kt
@@ -17,10 +17,14 @@
 package com.russhwolf.settings
 
 import platform.Foundation.NSUserDefaults
+import kotlin.native.concurrent.ensureNeverFrozen
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-private val factory = AppleSettings.Factory()
+private val factory = object : Settings.Factory {
+    val delegate = AppleSettings.Factory()
+    override fun create(name: String?): Settings = delegate.create(name).apply { ensureNeverFrozen() }
+}
 
 class AppleSettingsTest : BaseSettingsTest(factory) {
     @Test

--- a/tests/src/androidMain/kotlin/com/russhwolf/settings/ThreadSafeReference.kt
+++ b/tests/src/androidMain/kotlin/com/russhwolf/settings/ThreadSafeReference.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Russell Wolf
+ * Copyright 2020 Russell Wolf
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,18 @@
 
 package com.russhwolf.settings
 
-import kotlin.test.assertEquals
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
 
-@Suppress("KDocMissingDocumentation")
-class ListenerVerifier {
-    val listener: () -> Unit = { invokeCount = invokeCount?.plus(1) }
+actual fun <T> threadSafeReference(initialValue: T?) = object : ReadWriteProperty<Any?, T?> {
+    private val reference = AtomicReference<T?>(initialValue)
 
-    private var invokeCount by threadSafeReference(0)
-
-    fun assertInvoked(times: Int = 1, message: String? = null) {
-        assertEquals(times, invokeCount, message)
-        invokeCount = 0
+    override fun getValue(thisRef: Any?, property: KProperty<*>): T? {
+        return reference.get()
     }
 
-    fun assertNotInvoked(message: String? = null) {
-        assertInvoked(0, message)
+    override fun setValue(thisRef: Any?, property: KProperty<*>, value: T?) {
+        reference.set(value)
     }
 }

--- a/tests/src/commonMain/kotlin/com/russhwolf/settings/BaseSettingsTest.kt
+++ b/tests/src/commonMain/kotlin/com/russhwolf/settings/BaseSettingsTest.kt
@@ -33,7 +33,7 @@ abstract class BaseSettingsTest(
     private val hasListeners: Boolean = true,
     private val syncListeners: () -> Unit = {}
 ) {
-    private lateinit var settings: Settings
+    protected lateinit var settings: Settings
 
     private val settingsFactory: Settings.Factory = object : Settings.Factory {
         override fun create(name: String?): Settings = platformFactory.create(name).also { it.clear() }

--- a/tests/src/commonMain/kotlin/com/russhwolf/settings/ThreadSafeReference.kt
+++ b/tests/src/commonMain/kotlin/com/russhwolf/settings/ThreadSafeReference.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Russell Wolf
+ * Copyright 2020 Russell Wolf
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,6 @@
 
 package com.russhwolf.settings
 
-import kotlin.test.assertEquals
+import kotlin.properties.ReadWriteProperty
 
-@Suppress("KDocMissingDocumentation")
-class ListenerVerifier {
-    val listener: () -> Unit = { invokeCount = invokeCount?.plus(1) }
-
-    private var invokeCount by threadSafeReference(0)
-
-    fun assertInvoked(times: Int = 1, message: String? = null) {
-        assertEquals(times, invokeCount, message)
-        invokeCount = 0
-    }
-
-    fun assertNotInvoked(message: String? = null) {
-        assertInvoked(0, message)
-    }
-}
+expect fun <T> threadSafeReference(initialValue: T?): ReadWriteProperty<Any?, T?>

--- a/tests/src/jsMain/kotlin/com/russhwolf/settings/ThreadSafeReference.kt
+++ b/tests/src/jsMain/kotlin/com/russhwolf/settings/ThreadSafeReference.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Russell Wolf
+ * Copyright 2020 Russell Wolf
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,17 @@
 
 package com.russhwolf.settings
 
-import kotlin.test.assertEquals
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
 
-@Suppress("KDocMissingDocumentation")
-class ListenerVerifier {
-    val listener: () -> Unit = { invokeCount = invokeCount?.plus(1) }
+actual fun <T> threadSafeReference(initialValue: T?) = object : ReadWriteProperty<Any?, T?> {
+    private var reference: T? = initialValue
 
-    private var invokeCount by threadSafeReference(0)
-
-    fun assertInvoked(times: Int = 1, message: String? = null) {
-        assertEquals(times, invokeCount, message)
-        invokeCount = 0
+    override fun getValue(thisRef: Any?, property: KProperty<*>): T? {
+        return reference
     }
 
-    fun assertNotInvoked(message: String? = null) {
-        assertInvoked(0, message)
+    override fun setValue(thisRef: Any?, property: KProperty<*>, value: T?) {
+        reference = value
     }
 }

--- a/tests/src/jvmMain/kotlin/com/russhwolf/settings/ThreadSafeReference.kt
+++ b/tests/src/jvmMain/kotlin/com/russhwolf/settings/ThreadSafeReference.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Russell Wolf
+ * Copyright 2020 Russell Wolf
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,18 @@
 
 package com.russhwolf.settings
 
-import kotlin.test.assertEquals
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
 
-@Suppress("KDocMissingDocumentation")
-class ListenerVerifier {
-    val listener: () -> Unit = { invokeCount = invokeCount?.plus(1) }
+actual fun <T> threadSafeReference(initialValue: T?) = object : ReadWriteProperty<Any?, T?> {
+    private val reference = AtomicReference<T?>(initialValue)
 
-    private var invokeCount by threadSafeReference(0)
-
-    fun assertInvoked(times: Int = 1, message: String? = null) {
-        assertEquals(times, invokeCount, message)
-        invokeCount = 0
+    override fun getValue(thisRef: Any?, property: KProperty<*>): T? {
+        return reference.get()
     }
 
-    fun assertNotInvoked(message: String? = null) {
-        assertInvoked(0, message)
+    override fun setValue(thisRef: Any?, property: KProperty<*>, value: T?) {
+        reference.set(value)
     }
 }

--- a/tests/src/nativeMain/kotlin/com/russhwolf/settings/ThreadSafeReference.kt
+++ b/tests/src/nativeMain/kotlin/com/russhwolf/settings/ThreadSafeReference.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Russell Wolf
+ * Copyright 2020 Russell Wolf
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,18 @@
 
 package com.russhwolf.settings
 
-import kotlin.test.assertEquals
+import kotlin.native.concurrent.AtomicReference
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
 
-@Suppress("KDocMissingDocumentation")
-class ListenerVerifier {
-    val listener: () -> Unit = { invokeCount = invokeCount?.plus(1) }
+actual fun <T> threadSafeReference(initialValue: T?) = object : ReadWriteProperty<Any?, T?> {
+    private val reference = AtomicReference(initialValue)
 
-    private var invokeCount by threadSafeReference(0)
-
-    fun assertInvoked(times: Int = 1, message: String? = null) {
-        assertEquals(times, invokeCount, message)
-        invokeCount = 0
+    override fun getValue(thisRef: Any?, property: KProperty<*>): T? {
+        return reference.value
     }
 
-    fun assertNotInvoked(message: String? = null) {
-        assertInvoked(0, message)
+    override fun setValue(thisRef: Any?, property: KProperty<*>, value: T?) {
+        reference.value = value
     }
 }

--- a/tests/src/nativeMain/kotlin/com/russhwolf/settings/ThreadSafeReference.kt
+++ b/tests/src/nativeMain/kotlin/com/russhwolf/settings/ThreadSafeReference.kt
@@ -17,17 +17,18 @@
 package com.russhwolf.settings
 
 import kotlin.native.concurrent.AtomicReference
+import kotlin.native.concurrent.freeze
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
 actual fun <T> threadSafeReference(initialValue: T?) = object : ReadWriteProperty<Any?, T?> {
-    private val reference = AtomicReference(initialValue)
+    private val reference = AtomicReference(initialValue.freeze())
 
     override fun getValue(thisRef: Any?, property: KProperty<*>): T? {
         return reference.value
     }
 
     override fun setValue(thisRef: Any?, property: KProperty<*>, value: T?) {
-        reference.value = value
+        reference.value = value.freeze()
     }
 }


### PR DESCRIPTION
Trying to avoid forcing listeners to always freeze, by checking if the `Settings` is frozen and using that to signal whether listeners get frozen. I can't decide if that's elegant or terrible. 