### PR TITLE
Remove kotlin-dsl gradle plugin from buildSrc

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -15,17 +15,20 @@
  */
 
 plugins {
-    `kotlin-dsl`
+    kotlin("jvm") version "1.3.71"
 }
 
 repositories {
     google()
+    gradlePluginPortal()
     mavenCentral()
     jcenter()
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.70")
-    implementation("com.android.tools.build:gradle:3.6.1")
-    implementation("org.jetbrains.dokka:dokka-gradle-plugin:0.10.0")
+    implementation(kotlin("stdlib"))
+    implementation(kotlin("gradle-plugin"))
+    implementation("com.android.tools.build:gradle:3.6.2")
+    implementation("org.jetbrains.dokka:dokka-gradle-plugin:0.10.1")
+    implementation(kotlin("compiler-embeddable"))
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx2g
 android.useAndroidX=true
 #kotlin.mpp.enableGranularSourceSetsMetadata=true // Disabled due to KT-37155


### PR DESCRIPTION
This ensures we're not coupled to the embedded kotlin version, which was blocking doing a 1.4-M1 preview release