### PR TITLE
Fix README datastore maven library name

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ val blockingSettings: Settings = suspendSettings.toBlockingSettings()
 An implementation of `FlowSettings` on the Android exists in the `multiplatform-settings-datastore` dependency, based on [Jetpack DataStore](https://developer.android.com/jetpack/androidx/releases/datastore)
 
 ```kotlin
-implementation("com.russhwolf:multiplatform-settings-coroutines:0.7.2")
+implementation("com.russhwolf:multiplatform-settings-datastore:0.7.2")
 ```
 
 This provides a `DataStoreSettings` class


### PR DESCRIPTION
I'm sorry if I misunderstood something. The library name in the README seemed to be wrong, so I fixed it.