### PR TITLE
Factories return actual types

### DIFF
--- a/multiplatform-settings-test/api/android/multiplatform-settings-test.api
+++ b/multiplatform-settings-test/api/android/multiplatform-settings-test.api
@@ -52,7 +52,8 @@ public final class com/russhwolf/settings/MapSettings$Factory : com/russhwolf/se
 	public fun <init> ()V
 	public fun <init> (Lkotlin/jvm/functions/Function0;Ljava/util/Map;)V
 	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun create (Ljava/lang/String;)Lcom/russhwolf/settings/Settings;
+	public fun create (Ljava/lang/String;)Lcom/russhwolf/settings/MapSettings;
+	public synthetic fun create (Ljava/lang/String;)Lcom/russhwolf/settings/Settings;
 	public final fun setCacheValues (Ljava/lang/String;Ljava/util/Map;)V
 	public final fun setCacheValues (Ljava/lang/String;[Lkotlin/Pair;)V
 }

--- a/multiplatform-settings-test/api/jvm/multiplatform-settings-test.api
+++ b/multiplatform-settings-test/api/jvm/multiplatform-settings-test.api
@@ -52,7 +52,8 @@ public final class com/russhwolf/settings/MapSettings$Factory : com/russhwolf/se
 	public fun <init> ()V
 	public fun <init> (Lkotlin/jvm/functions/Function0;Ljava/util/Map;)V
 	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun create (Ljava/lang/String;)Lcom/russhwolf/settings/Settings;
+	public fun create (Ljava/lang/String;)Lcom/russhwolf/settings/MapSettings;
+	public synthetic fun create (Ljava/lang/String;)Lcom/russhwolf/settings/Settings;
 	public final fun setCacheValues (Ljava/lang/String;Ljava/util/Map;)V
 	public final fun setCacheValues (Ljava/lang/String;[Lkotlin/Pair;)V
 }

--- a/multiplatform-settings-test/src/commonMain/kotlin/com/russhwolf/settings/MapSettings.kt
+++ b/multiplatform-settings-test/src/commonMain/kotlin/com/russhwolf/settings/MapSettings.kt
@@ -80,7 +80,7 @@ public class MapSettings public constructor(private val delegate: MutableMap<Str
             setCacheValues(name, mapFactory().apply { putAll(items) })
         }
 
-        public override fun create(name: String?): ObservableSettings {
+        public override fun create(name: String?): MapSettings {
             val delegate = delegateCache.getOrPut(name, mapFactory)
             return MapSettings(delegate)
         }

--- a/multiplatform-settings-test/src/commonMain/kotlin/com/russhwolf/settings/MapSettings.kt
+++ b/multiplatform-settings-test/src/commonMain/kotlin/com/russhwolf/settings/MapSettings.kt
@@ -80,7 +80,7 @@ public class MapSettings public constructor(private val delegate: MutableMap<Str
             setCacheValues(name, mapFactory().apply { putAll(items) })
         }
 
-        public override fun create(name: String?): Settings {
+        public override fun create(name: String?): ObservableSettings {
             val delegate = delegateCache.getOrPut(name, mapFactory)
             return MapSettings(delegate)
         }

--- a/multiplatform-settings/api/android/multiplatform-settings.api
+++ b/multiplatform-settings/api/android/multiplatform-settings.api
@@ -239,7 +239,8 @@ public final class com/russhwolf/settings/SharedPreferencesSettings : com/russhw
 
 public final class com/russhwolf/settings/SharedPreferencesSettings$Factory : com/russhwolf/settings/Settings$Factory {
 	public fun <init> (Landroid/content/Context;)V
-	public fun create (Ljava/lang/String;)Lcom/russhwolf/settings/Settings;
+	public synthetic fun create (Ljava/lang/String;)Lcom/russhwolf/settings/Settings;
+	public fun create (Ljava/lang/String;)Lcom/russhwolf/settings/SharedPreferencesSettings;
 }
 
 public final class com/russhwolf/settings/SharedPreferencesSettings$Listener : com/russhwolf/settings/SettingsListener {

--- a/multiplatform-settings/api/jvm/multiplatform-settings.api
+++ b/multiplatform-settings/api/jvm/multiplatform-settings.api
@@ -178,7 +178,8 @@ public final class com/russhwolf/settings/PreferencesSettings$Factory : com/russ
 	public fun <init> ()V
 	public fun <init> (Ljava/util/prefs/Preferences;)V
 	public synthetic fun <init> (Ljava/util/prefs/Preferences;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun create (Ljava/lang/String;)Lcom/russhwolf/settings/Settings;
+	public fun create (Ljava/lang/String;)Lcom/russhwolf/settings/PreferencesSettings;
+	public synthetic fun create (Ljava/lang/String;)Lcom/russhwolf/settings/Settings;
 }
 
 public final class com/russhwolf/settings/PreferencesSettings$Listener : com/russhwolf/settings/SettingsListener {

--- a/multiplatform-settings/src/androidMain/kotlin/com/russhwolf/settings/SharedPreferencesSettings.kt
+++ b/multiplatform-settings/src/androidMain/kotlin/com/russhwolf/settings/SharedPreferencesSettings.kt
@@ -81,7 +81,7 @@ public class SharedPreferencesSettings @JvmOverloads public constructor(
          * On the Android platform, this is implemented by calling [Context.getSharedPreferences] and passing [name]. If
          * `name` is `null` then a default package-specific name will be used instead.
          */
-        public override fun create(name: String?): Settings {
+        public override fun create(name: String?): ObservableSettings {
             // For null name, match the behavior of PreferenceManager.getDefaultSharedPreferences()
             val preferencesName = name ?: "${appContext.packageName}_preferences"
             val delegate = appContext.getSharedPreferences(preferencesName, MODE_PRIVATE)

--- a/multiplatform-settings/src/androidMain/kotlin/com/russhwolf/settings/SharedPreferencesSettings.kt
+++ b/multiplatform-settings/src/androidMain/kotlin/com/russhwolf/settings/SharedPreferencesSettings.kt
@@ -81,7 +81,7 @@ public class SharedPreferencesSettings @JvmOverloads public constructor(
          * On the Android platform, this is implemented by calling [Context.getSharedPreferences] and passing [name]. If
          * `name` is `null` then a default package-specific name will be used instead.
          */
-        public override fun create(name: String?): ObservableSettings {
+        public override fun create(name: String?): SharedPreferencesSettings {
             // For null name, match the behavior of PreferenceManager.getDefaultSharedPreferences()
             val preferencesName = name ?: "${appContext.packageName}_preferences"
             val delegate = appContext.getSharedPreferences(preferencesName, MODE_PRIVATE)

--- a/multiplatform-settings/src/appleMain/kotlin/com/russhwolf/settings/KeychainSettings.kt
+++ b/multiplatform-settings/src/appleMain/kotlin/com/russhwolf/settings/KeychainSettings.kt
@@ -108,7 +108,7 @@ public class KeychainSettings(vararg defaultProperties: Pair<CFStringRef?, CFTyp
      * This class creates `Settings` objects backed by the Apple keychain.
      */
     public class Factory : Settings.Factory {
-        override fun create(name: String?): Settings =
+        override fun create(name: String?): KeychainSettings =
             if (name != null) KeychainSettings(name) else KeychainSettings()
     }
 

--- a/multiplatform-settings/src/appleMain/kotlin/com/russhwolf/settings/NSUserDefaultsSettings.kt
+++ b/multiplatform-settings/src/appleMain/kotlin/com/russhwolf/settings/NSUserDefaultsSettings.kt
@@ -88,7 +88,7 @@ public class NSUserDefaultsSettings public constructor(
          * On the iOS and macOS platforms, this is implemented by calling [NSUserDefaults.init] and passing [name]. If `name` is
          * `null` then [NSUserDefaults.standardUserDefaults] will be used instead.
          */
-        public override fun create(name: String?): Settings {
+        public override fun create(name: String?): ObservableSettings {
             val delegate = if (name == null) NSUserDefaults.standardUserDefaults else NSUserDefaults(suiteName = name)
             return NSUserDefaultsSettings(delegate)
         }

--- a/multiplatform-settings/src/appleMain/kotlin/com/russhwolf/settings/NSUserDefaultsSettings.kt
+++ b/multiplatform-settings/src/appleMain/kotlin/com/russhwolf/settings/NSUserDefaultsSettings.kt
@@ -88,7 +88,7 @@ public class NSUserDefaultsSettings public constructor(
          * On the iOS and macOS platforms, this is implemented by calling [NSUserDefaults.init] and passing [name]. If `name` is
          * `null` then [NSUserDefaults.standardUserDefaults] will be used instead.
          */
-        public override fun create(name: String?): ObservableSettings {
+        public override fun create(name: String?): NSUserDefaultsSettings {
             val delegate = if (name == null) NSUserDefaults.standardUserDefaults else NSUserDefaults(suiteName = name)
             return NSUserDefaultsSettings(delegate)
         }

--- a/multiplatform-settings/src/commonMain/kotlin/com/russhwolf/settings/Settings.kt
+++ b/multiplatform-settings/src/commonMain/kotlin/com/russhwolf/settings/Settings.kt
@@ -30,7 +30,7 @@ public interface Settings {
     public companion object;
 
     /**
-     * A factory that can produce [Settings] instances.
+     * A factory that can produce [Settings] instances or derivations thereof.
      */
     public interface Factory {
         /**

--- a/multiplatform-settings/src/jvmMain/kotlin/com/russhwolf/settings/PreferencesSettings.kt
+++ b/multiplatform-settings/src/jvmMain/kotlin/com/russhwolf/settings/PreferencesSettings.kt
@@ -63,7 +63,7 @@ public class PreferencesSettings public constructor(
      * On the JVM platform, this class creates `Settings` objects backed by [Preferences].
      */
     public class Factory(private val rootPreferences: Preferences = Preferences.userRoot()) : Settings.Factory {
-        public override fun create(name: String?): ObservableSettings {
+        public override fun create(name: String?): PreferencesSettings {
             val preferences = if (name != null) rootPreferences.node(name) else rootPreferences
             return PreferencesSettings(preferences)
         }

--- a/multiplatform-settings/src/jvmMain/kotlin/com/russhwolf/settings/PreferencesSettings.kt
+++ b/multiplatform-settings/src/jvmMain/kotlin/com/russhwolf/settings/PreferencesSettings.kt
@@ -63,7 +63,7 @@ public class PreferencesSettings public constructor(
      * On the JVM platform, this class creates `Settings` objects backed by [Preferences].
      */
     public class Factory(private val rootPreferences: Preferences = Preferences.userRoot()) : Settings.Factory {
-        public override fun create(name: String?): Settings {
+        public override fun create(name: String?): ObservableSettings {
             val preferences = if (name != null) rootPreferences.node(name) else rootPreferences
             return PreferencesSettings(preferences)
         }

--- a/multiplatform-settings/src/mingwX64Main/kotlin/com/russhwolf/settings/RegistrySettings.kt
+++ b/multiplatform-settings/src/mingwX64Main/kotlin/com/russhwolf/settings/RegistrySettings.kt
@@ -98,7 +98,7 @@ public class RegistrySettings public constructor(private val rootKeyName: String
      * Instances created by this factory will be subkeys of that key.
      */
     public class Factory(private val parentKeyName: String) : Settings.Factory {
-        public override fun create(name: String?): Settings {
+        public override fun create(name: String?): RegistrySettings {
             val key = "SOFTWARE\\$parentKeyName" + if (name != null) "\\$name" else ""
             return RegistrySettings(key)
         }


### PR DESCRIPTION
As discussed [here](https://github.com/russhwolf/multiplatform-settings/issues/125#issuecomment-1243118303), Factories that create `ObservableSettings` now return that type. Therefore casting to `ObservableSettings` is not required anymore.

Update: As discussed here, factories now return the actual types.

Closes #125