### PR TITLE
Fix crash when creating 'KeychainSettings' without name on mac.

### DIFF
--- a/multiplatform-settings/src/appleMain/kotlin/com/russhwolf/settings/KeychainSettings.kt
+++ b/multiplatform-settings/src/appleMain/kotlin/com/russhwolf/settings/KeychainSettings.kt
@@ -131,13 +131,15 @@ public class KeychainSettings @ExperimentalSettingsApi constructor(vararg defaul
             }
 
             @Suppress("RemoveRedundantCallsOfConversionMethods") // IDE thinks CFIndex == Int but might be Long
-            val list = List(CFArrayGetCount(attributes.value).toInt()) { i ->
+            val size = CFArrayGetCount(attributes.value).toInt()
+            return (0 until size).mapNotNullTo(mutableSetOf()) { i ->
                 val item: CFDictionaryRef? = CFArrayGetValueAtIndex(attributes.value, i.toCFIndex())?.reinterpret()
                 val cfKey: CFStringRef? = CFDictionaryGetValue(item, kSecAttrAccount)?.reinterpret()
-                val nsKey = CFBridgingRelease(cfKey) as NSString
-                nsKey.toKString()
+                if (cfKey != null) {
+                    val nsKey = CFBridgingRelease(cfKey) as NSString
+                    nsKey.toKString()
+                } else null
             }
-            return list.toSet()
         }
 
     public override val size: Int get() = keys.size

--- a/multiplatform-settings/src/appleMain/kotlin/com/russhwolf/settings/KeychainSettings.kt
+++ b/multiplatform-settings/src/appleMain/kotlin/com/russhwolf/settings/KeychainSettings.kt
@@ -130,15 +130,15 @@ public class KeychainSettings @ExperimentalSettingsApi constructor(vararg defaul
                 return emptySet()
             }
 
-            @Suppress("RemoveRedundantCallsOfConversionMethods") // IDE thinks CFIndex == Int but might be Long
-            val size = CFArrayGetCount(attributes.value).toInt()
-            return (0 until size).mapNotNullTo(mutableSetOf()) { i ->
-                val item: CFDictionaryRef? = CFArrayGetValueAtIndex(attributes.value, i.toCFIndex())?.reinterpret()
-                val cfKey: CFStringRef? = CFDictionaryGetValue(item, kSecAttrAccount)?.reinterpret()
-                if (cfKey != null) {
-                    val nsKey = CFBridgingRelease(cfKey) as NSString
-                    nsKey.toKString()
-                } else null
+            return buildSet {
+                for (i in 0..<CFArrayGetCount(attributes.value)) {
+                    val item: CFDictionaryRef? = CFArrayGetValueAtIndex(attributes.value, i.toCFIndex())?.reinterpret()
+                    val cfKey: CFStringRef? = CFDictionaryGetValue(item, kSecAttrAccount)?.reinterpret()
+                    if (cfKey != null) {
+                        val nsKey = CFBridgingRelease(cfKey) as NSString
+                        add(nsKey.toKString())
+                    }
+                }
             }
         }
 

--- a/multiplatform-settings/src/macosX64Test/kotlin/com/russhwolf/settings/KeychainSettingsTest.kt
+++ b/multiplatform-settings/src/macosX64Test/kotlin/com/russhwolf/settings/KeychainSettingsTest.kt
@@ -37,7 +37,6 @@ import platform.Security.kSecMatchLimitOne
 import platform.Security.kSecReturnData
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 // TODO figure out how to get this running on ios, watchos, and tvos simulators
 @ExperimentalSettingsImplementation
@@ -78,6 +77,8 @@ class KeychainSettingsTest : BaseSettingsTest(
     @Test
     fun keys_no_name() {
         val settings = KeychainSettings()
-        assertTrue(settings.keys.isNotEmpty())
+
+        // Ensure this doesn't throw
+        settings.keys
     }
 }

--- a/multiplatform-settings/src/macosX64Test/kotlin/com/russhwolf/settings/KeychainSettingsTest.kt
+++ b/multiplatform-settings/src/macosX64Test/kotlin/com/russhwolf/settings/KeychainSettingsTest.kt
@@ -37,6 +37,7 @@ import platform.Security.kSecMatchLimitOne
 import platform.Security.kSecReturnData
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 // TODO figure out how to get this running on ios, watchos, and tvos simulators
 @ExperimentalSettingsImplementation
@@ -72,5 +73,11 @@ class KeychainSettingsTest : BaseSettingsTest(
             settings -= "key"
         }
         assertEquals("value", value)
+    }
+
+    @Test
+    fun keys_no_name() {
+        val settings = KeychainSettings()
+        assertTrue(settings.keys.isNotEmpty())
     }
 }


### PR DESCRIPTION
There is an edge case with creating `KeychainSettings` on Mac with no name and calling `keys` variable. Because `kSecAttrService` is not set you get a bunch of random values which might not have `kSecAttrAccount` set so the call fails with `NullPointerException`. Not sure if the fix style and new test assertion work for you, just wanted to raise the issue. Tested on m2 mac.